### PR TITLE
Air Module Rebalance

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/SPT-Mod-Dev.iml
+++ b/.idea/SPT-Mod-Dev.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="17" project-jdk-type="JavaSDK">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/SPT-Mod-Dev.iml" filepath="$PROJECT_DIR$/.idea/SPT-Mod-Dev.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/common/units/equipment/modules/00_plane_modules.txt
+++ b/common/units/equipment/modules/00_plane_modules.txt
@@ -648,9 +648,9 @@ equipment_modules = {
 		add_equipment_type = { fighter heavy_fighter }
 
 		add_stats = {
-			air_attack = 9
+			air_attack = 11         #2xHMGs were worse than 4xLMGs per slot. Rebalanced to still be worse in weight/damage, but better per slot. DMG/weight ratio is slightly better than 2xHMG cuz rounding.
 			build_cost_ic = 1.5
-			weight = 2.5
+			weight = 3
 		}
 		xp_cost = 0
 		allow_mission_type = {
@@ -696,15 +696,23 @@ equipment_modules = {
 		add_equipment_type = { fighter heavy_fighter }
 
 		add_stats = {
-			air_attack = 10
+			air_attack = 14             #Single cannon Damage per Weight now on Par with double cannon Damage, rounded up. Still worse per slot/weight than 4xHMG.
 			build_cost_ic = 2.5
 			air_agility = -1
-			weight = 3
+			weight = 4
 		}
 		xp_cost = 0
 		allow_mission_type = {
 			air_superiority
 			interception
+		}
+        mission_type_stats = {
+			limit = {
+				cas                     #Logi strike is banished to the shadow realm
+			}
+			add_stats = {
+				air_ground_attack = 2   #Make cannons a bonus on hybrid designs, as their normal weight to attack ratio is worse than LMGS
+			}
 		}
 	}
 
@@ -727,10 +735,10 @@ equipment_modules = {
 		}
 		mission_type_stats = {
 			limit = {
-				attack_logistics
+				cas                     #Logi strike is banished to the shadow realm
 			}
 			add_stats = {
-				air_ground_attack = 2
+				air_ground_attack = 2   #Make cannons a bonus on hybrid designs, as their normal weight to attack ratio is worse than LMGS
 			}
 		}
 		can_convert_from = {
@@ -746,7 +754,7 @@ equipment_modules = {
 		parent = aircraft_cannon_1_1x
 		add_equipment_type = { fighter heavy_fighter }
 		add_stats = {
-			air_attack = 12
+			air_attack = 14
 			build_cost_ic = 3
 			air_agility = -0.5
 			weight = 3
@@ -755,6 +763,14 @@ equipment_modules = {
 		allow_mission_type = {
 			air_superiority
 			interception
+		}
+        mission_type_stats = {
+			limit = {
+				cas                     #Logi strike is banished to the shadow realm
+			}
+			add_stats = {
+				air_ground_attack = 1   #Make cannons a bonus on hybrid designs, as their normal weight to attack ratio is worse than LMGS
+			}
 		}
 	}
 
@@ -777,10 +793,10 @@ equipment_modules = {
 		}
 		mission_type_stats = {
 			limit = {
-				attack_logistics
+				cas                     #Logi strike is banished to the shadow realm
 			}
 			add_stats = {
-				air_ground_attack = 2
+				air_ground_attack = 2   #Make cannons a bonus on hybrid designs, as their normal weight to attack ratio is worse than LMGS
 			}
 		}
 		can_convert_from = {
@@ -806,6 +822,14 @@ equipment_modules = {
 			air_superiority
 			interception
 		}
+		mission_type_stats = {
+        	limit = {
+        		cas                     #Logi strike is banished to the shadow realm
+        	}
+        	add_stats = {
+        		air_ground_attack = 2   #Big guns good at shooting stuff on ground
+        	}
+        }
 	}
 
 	large_aircraft_cannon_2x = {
@@ -827,10 +851,10 @@ equipment_modules = {
 		}
 		mission_type_stats = {
 			limit = {
-				attack_logistics
+				cas                     #Logi strike is banished to the shadow realm
 			}
 			add_stats = {
-				air_ground_attack = 2
+				air_ground_attack = 4   #Big guns good at shooting stuff on ground
 			}
 		}
 		can_convert_from = {
@@ -849,15 +873,14 @@ equipment_modules = {
 			build_cost_ic = 6 #SPTchange 1 -> 6
 		}
 		xp_cost = 0
-		allow_mission_type = {
+		allow_mission_type = {       #Logi strike is banished to the shadow realm. Historical ability to port strike on par with small bomb bay is added
 			cas
-			attack_logistics
 			naval_bomber
+			port_strike
 		}
 		mission_type_stats = {
 			limit = {
 				cas
-				attack_logistics
 			}
 			add_stats = {
 				air_agility = -15
@@ -868,6 +891,7 @@ equipment_modules = {
 		mission_type_stats = {
 			limit = {
 				naval_bomber
+				port_strike
 			}
 			add_stats = {
 				air_agility = -15
@@ -888,18 +912,17 @@ equipment_modules = {
 		add_equipment_type = cas
 
 		add_stats = {
-			build_cost_ic = 1
+			build_cost_ic = 6   #Brought on Par with change to base bomb locks
 		}
 		xp_cost = 0
-		allow_mission_type = {
+		allow_mission_type = {  #Logi strike is banished to the shadow realm. Historical ability to port strike on par with small bomb bay is added
 			cas
-			attack_logistics
+			port_strike
 			naval_bomber
 		}
 		mission_type_stats = {
 			limit = {
 				cas
-				attack_logistics
 			}
 			add_stats = {
 				air_agility = -20
@@ -910,6 +933,7 @@ equipment_modules = {
 		mission_type_stats = {
 			limit = {
 				naval_bomber
+				port_strike
 			}
 			add_stats = {
 				air_agility = -20
@@ -930,18 +954,17 @@ equipment_modules = {
 		add_equipment_type = cas
 
 		add_stats = {
-			build_cost_ic = 1
+			build_cost_ic = 6   #Brought on Par with change to base bomb locks
 		}
 		xp_cost = 0
-		allow_mission_type = {
+		allow_mission_type = {  #Logi strike is banished to the shadow realm. Historical ability to port strike on par with small bomb bay is added
 			cas
-			attack_logistics
+			port_strike
 			naval_bomber
 		}
 		mission_type_stats = {
 			limit = {
 				cas
-				attack_logistics
 			}
 			add_stats = {
 				air_agility = -20
@@ -952,6 +975,7 @@ equipment_modules = {
 		mission_type_stats = {
 			limit = {
 				naval_bomber
+				port_strike
 			}
 			add_stats = {
 				air_agility = -20
@@ -976,14 +1000,12 @@ equipment_modules = {
 			build_cost_ic = 3 #SPTchange 1 -> 4
 		}
 		xp_cost = 0
-		allow_mission_type = {
+		allow_mission_type = {  #Logi strike is banished to the shadow realm. Historical ability to port strike on par with small bomb bay is added
 			cas
-			attack_logistics
 		}
 		mission_type_stats = {
 			limit = {
 				cas
-				attack_logistics
 			}
 			add_stats = {
 				air_ground_attack = 6 #SPTchange 4 -> 6
@@ -1005,18 +1027,16 @@ equipment_modules = {
 		add_stats = {
 			build_cost_ic = 3
 			weight = 2
-			
+
 		}
 		xp_cost = 0
-		allow_mission_type = {
+		allow_mission_type = {  #Logi strike is banished to the shadow realm.
 			cas
-			attack_logistics
 			port_strike
 		}
 		mission_type_stats = {
 			limit = {
 				cas
-				attack_logistics
 			}
 			add_stats = {
 				air_ground_attack = 8
@@ -1051,16 +1071,13 @@ equipment_modules = {
 			weight = 1
 		}
 		xp_cost = 0
-		allow_mission_type = {
+		allow_mission_type = { #Statless ability to port strike Removed. As with small planes Bombers can exclusively use torps or bombs, loading bombs on a Medium Torp bomber thus makes no sense and seems like an oversight. Also, Logi strike is banished to the shadow realm.
 			cas
-			attack_logistics
 			strategic_bomber
-			port_strike
 		}
 		mission_type_stats = {
 			limit = {
 				cas
-				attack_logistics
 				port_strike
 			}
 			add_stats = {
@@ -1132,9 +1149,8 @@ equipment_modules = {
 			air_agility = -15
 		}
 		xp_cost = 0
-		allow_mission_type = {
+		allow_mission_type = {  #Logi strike is banished to the shadow realm.
 			cas
-			attack_logistics
 		}
 		dismantle_cost_ic = 1.5
 	}
@@ -1152,9 +1168,8 @@ equipment_modules = {
 			air_agility = -20
 		}
 		xp_cost = 0
-		allow_mission_type = {
+		allow_mission_type = {  #Logi strike is banished to the shadow realm.
 			cas
-			attack_logistics
 		}
 		dismantle_cost_ic = 3.5
 	}


### PR DESCRIPTION
Changes Air attack values of some HMGs And Cannons to make some modul…es not just objectively worse.
Transfers Ground Attack Bonuses from Logi strike to Cas, adds them to all cannons (half for single cannons). Doubles Ground Attack Bonuses for large cannons. Still needs a cas Module to apply. Logi strike is banished to the shadow realm.
Bomb locks can now port Strike. Historical, makes CVCas more into the "Can do everything worse for the same price"/"Better at more cost" Role until Torp 3/Guided ASM/Engine 4 enter the tech pool