### PR TITLE
No red france

### DIFF
--- a/events/ElectionEvents.txt
+++ b/events/ElectionEvents.txt
@@ -318,7 +318,8 @@ country_event = {
 			ideology = communism
 			popularity = 0.1
 		}
-		set_country_flag = coalition_with_communists
+		# SPT Change - No more communists in government (prevent red events)
+		#set_country_flag = coalition_with_communists
 	}
 
 	option = {

--- a/events/ElectionEvents.txt
+++ b/events/ElectionEvents.txt
@@ -320,6 +320,7 @@ country_event = {
 		}
 		# SPT Change - No more communists in government (prevent red events)
 		#set_country_flag = coalition_with_communists
+		set_country_flag = government_declined_communists
 	}
 
 	option = {


### PR DESCRIPTION
Early on France gets an event to either invite communists to power for 10% communist support or lose 5% stability and increase in 3% democratic support. If France takes the coalition route, it will raise a hidden coalition flag, and over time it will be spammed an event to get 5% communist support or lose 5 stability over and over (election.8); this is usually the source of red Frances in mp. This get rids of that flag. The other flag, although not used in the game files in any other place, is raised due to election events being triggered in a black box beyond the modders control, and the risk it is checked for spamming the above mentioned coalition event.